### PR TITLE
Simplify service to not require attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ module.exports = function(environment) {
     'ember-api-feature-flags': {
       featureUrl: 'https://www.example.com/api/v1/features',
       featureKey: 'feature_key',
-      attributes: ['id', 'key', 'value'],
+      enabledKey: 'value',
       shouldMemoize: true,
       defaultValue: false
     }
@@ -103,9 +103,21 @@ This key is the key on your feature flag data object yielding the feature's name
 
 The value on this key will be normalized by the [`normalizeKey`](#normalizeKey) method.
 
-### `attributes {Array<string>} = ['id', 'key', 'value']`
+### `enabledKey {Boolean} = 'value'`
 
-This determines which keys to pick off of the feature flag data object. These values are then used by the `FeatureFlag` object (a wrapper around the single feature flag) when determining if a feature flag is enabled.
+This determines which key to pick off of the feature flag data object. This value is then used by the `FeatureFlag` object (a wrapper around the single feature flag) when determining if a feature flag is enabled.
+
+```js
+// example feature flag data object
+{
+  "id": 26,
+  "feature_key": "new_profile_page",
+  "key": "boolean",
+  "value": "true", // <-
+  "created_at": "2017-03-22T03:30:10.270Z",
+  "updated_at": "2017-03-22T03:30:10.270Z"
+}
+```
 
 ### `shouldMemoize {Boolean} = true`
 
@@ -144,16 +156,8 @@ let data = service.get('data');
 
 /**
   {
-    "newProfilePage": {
-      "id": 26,
-      "key": "boolean",
-      "value": "true"
-    },
-    "newFriendList": {
-      "id": 27,
-      "key": "boolean",
-      "value": "true"
-    }
+    "newProfilePage": { value: "true" },
+    "newFriendList": { value: "true" }
   }
 **/
 ```
@@ -168,7 +172,7 @@ Configure the service. You can use this method to change service options at runt
 service.configure({
   featureUrl: 'http://www.example.com/features',
   featureKey: 'feature_key',
-  attributes: ['id', 'key', 'value'],
+  enabledKey: 'value',
   shouldMemoize: true,
   defaultValue: false
 });

--- a/addon/services/feature-flags.js
+++ b/addon/services/feature-flags.js
@@ -18,7 +18,7 @@ const {
 const SERVICE_OPTIONS = [
   'featureUrl',
   'featureKey',
-  'attributes',
+  'enabledKey',
   'shouldMemoize',
   'defaultValue'
 ];
@@ -274,7 +274,7 @@ export default Service.extend({
   _normalizeData(data, featureKey = get(this, 'featureKey')) {
     return data.reduce((acc, d) => {
       let normalizedKey = this.normalizeKey(d[featureKey]);
-      acc[normalizedKey] = pick(d, get(this, 'attributes'));
+      acc[normalizedKey] = pick(d, [get(this, 'enabledKey')]);
       return acc;
     }, {});
   }

--- a/app/initializers/feature-flags.js
+++ b/app/initializers/feature-flags.js
@@ -26,7 +26,7 @@ const FEATURE_FLAG_DEFAULTS = {
    * @public
    * @property {Array<string>}
    */
-  attributes: ['id', 'key', 'value'],
+  attributes: ['id', 'value'],
 
   /**
    * If true, will cache FeatureFlag objects.

--- a/tests/unit/feature-flag/index-test.js
+++ b/tests/unit/feature-flag/index-test.js
@@ -52,8 +52,3 @@ test('computed - #isDisabled - when false as string', function(assert) {
   let featureFlag = FeatureFlag.create({ data: { key: 'boolean', value: 'false' } });
   assert.ok(featureFlag.get('isDisabled'), 'should be disabled');
 });
-
-test('when type is not handled', function(assert) {
-  let featureFlag = FeatureFlag.create({ data: { key: 'foobar', value: false } });
-  assert.throws(() => featureFlag.get('isEnabled'), 'should throw error');
-});

--- a/tests/unit/services/feature-flags-test.js
+++ b/tests/unit/services/feature-flags-test.js
@@ -2,10 +2,11 @@ import Ember from 'ember';
 import { moduleFor, test } from 'ember-qunit';
 
 const { typeOf } = Ember;
+const { keys } = Object;
 const defaultOptions = {
   featureUrl: 'http://www.example.com/features',
   featureKey: 'feature_key',
-  attributes: ['id', 'key', 'value'],
+  enabledKey: 'value',
   shouldMemoize: true,
   defaultValue: false
 };
@@ -22,16 +23,14 @@ test('#configure should set options on service', function(assert) {
   let options = {
     featureUrl: 'http://www.example.com/features',
     featureKey: 'key',
-    attributes: ['a', 'b', 'c'],
+    enabledKey: 'value',
     shouldMemoize: true,
     defaultValue: false
   };
   service.configure(options);
-  assert.equal(service.get('featureUrl'), options.featureUrl, 'should set option');
-  assert.equal(service.get('featureKey'), options.featureKey, 'should set option');
-  assert.deepEqual(service.get('attributes'), options.attributes, 'should set option');
-  assert.equal(service.get('shouldMemoize'), options.shouldMemoize, 'should set option');
-  assert.equal(service.get('defaultValue'), options.defaultValue, 'should set option');
+  keys(options).forEach((k) => {
+    assert.equal(service.get(k), options[k], 'should set option');
+  });
 });
 
 test('#fetchFeatures', function(assert) {
@@ -78,7 +77,7 @@ test('computed - #data', function(assert) {
     .receiveData([
       { 'feature_key': 'foo_bar', key: 'boolean', value: true }
     ]);
-  assert.deepEqual(service.get('data'), { fooBar: { key: 'boolean', value: true } }, 'should normalize data');
+  assert.deepEqual(service.get('data'), { fooBar: { value: true } }, 'should normalize data');
 });
 
 test('#normalizeKey', function(assert) {

--- a/tests/unit/utils/pick-test.js
+++ b/tests/unit/utils/pick-test.js
@@ -1,0 +1,11 @@
+import pick from 'ember-api-feature-flags/utils/pick';
+import { module, test } from 'qunit';
+
+module('Unit | Utility | pick');
+
+test('it picks key/value pairs off an object', function(assert) {
+  let obj = { foo: '123', bar: '456', baz: '789' };
+  assert.deepEqual(pick(obj, ['foo', 'baz']), { foo: '123', baz: '789' });
+  assert.deepEqual(pick(obj, ['bar', 'baz']), { bar: '456', baz: '789' });
+  assert.deepEqual(obj, { foo: '123', bar: '456', baz: '789' }, 'does not mutate object');
+});


### PR DESCRIPTION
Doesn't really make sense for the client to handle different kinds of
feature flag types. The API should just return boolean values.