### PR TITLE
Add support for deferring fetch

### DIFF
--- a/app/initializers/feature-flags.js
+++ b/app/initializers/feature-flags.js
@@ -9,7 +9,18 @@ const {
 } = Ember;
 const FEATURE_FLAG_DEFAULTS = {
   /**
+   * If true, will not automatically fetch feature flags.
+   *
+   * @public
+   * @property {Boolean}
+   */
+  isDeferred: false,
+
+  /**
    * Feature API endpoint.
+   *
+   * @public
+   * @property {String}
    */
   featureUrl: undefined,
   /**
@@ -46,12 +57,18 @@ export function initialize(application) {
   if (isNone(featureFlagService)) {
     return;
   }
-  featureFlagService
-    .configure(options)
-    .fetchFeatures()
-    .then((data) => featureFlagService.receiveData(data))
-    .catch((reason) => featureFlagService.receiveError(reason))
-    .finally(() => application.advanceReadiness());
+
+  featureFlagService.configure(options);
+
+  if (!options.isDeferred) {
+    featureFlagService
+      .fetchFeatures()
+      .then((data) => featureFlagService.receiveData(data))
+      .catch((reason) => featureFlagService.receiveError(reason))
+      .finally(() => application.advanceReadiness());
+  } else {
+    application.advanceReadiness();
+  }
 }
 
 export default {

--- a/tests/unit/feature-flag/index-test.js
+++ b/tests/unit/feature-flag/index-test.js
@@ -1,5 +1,8 @@
+import Ember from 'ember';
 import FeatureFlag from 'ember-api-feature-flags/feature-flag';
 import { module, test } from 'qunit';
+
+const { Evented, Object: EmberObject } = Ember;
 
 module('Unit | Utility | feature flag');
 
@@ -51,4 +54,21 @@ test('computed - #isDisabled - when false', function(assert) {
 test('computed - #isDisabled - when false as string', function(assert) {
   let featureFlag = FeatureFlag.create({ data: { key: 'boolean', value: 'false' } });
   assert.ok(featureFlag.get('isDisabled'), 'should be disabled');
+});
+
+test('when deferred - should listen for `didFetchData`', function(assert) {
+  let DummyService = EmberObject.extend(Evented, {
+    data: { foo: { key: 'boolean', value: 'true' } },
+    do(eventName) { this.trigger(eventName); }
+  });
+  let service = DummyService.create();
+  let featureFlag = FeatureFlag.create({
+    isDeferred: true,
+    __service__: service,
+    __key__: 'foo',
+    data: { key: 'boolean', value: 'false' }
+  });
+  assert.ok(featureFlag.get('isDisabled'), 'precondition - should be disabled');
+  service.do('didFetchData');
+  assert.ok(featureFlag.get('isEnabled'), 'should be enabled');
 });

--- a/tests/unit/services/feature-flags-test.js
+++ b/tests/unit/services/feature-flags-test.js
@@ -7,6 +7,7 @@ const defaultOptions = {
   featureUrl: 'http://www.example.com/features',
   featureKey: 'feature_key',
   enabledKey: 'value',
+  isDeferred: false,
   shouldMemoize: true,
   defaultValue: false
 };


### PR DESCRIPTION
Consuming application needs to manually call the fetch. You can include
headers (e.g. auth) here.